### PR TITLE
Add app_token authentication to bypass rate-limited login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
 *pyc
 *bk
 *swp
+
+# Sensitive files
+.env
+.env.*
+
+# Data files
+data/
+*.log

--- a/README.md
+++ b/README.md
@@ -24,9 +24,130 @@ The script is designed to run as a docker container and so takes its configurati
 - `INFLUXDB_MEASUREMENT`: The measurement name to write into (default `zepp`)
 - `INFLUXDB_BUCKET`: The bucket/database to write into (default `telegraf`)
 - `QUERY_DURATION`: How many days data to fetch from the API (default 2)
+
+**Authentication (choose one):**
+
+*Option 1: Email/Password*
 - `ZEPP_EMAIL`: The email address used to sign into Zepp/MiFit/Huami/Amznfit
 - `ZEPP_PASS`: The password to your Zepp account
 
+*Option 2: App Token (recommended)*
+- `ZEPP_APP_TOKEN`: App token extracted from Zepp mobile app
+- `ZEPP_USER_ID`: Your Zepp user ID
+
+> **Why use Option 2?** The Zepp API has strict rate limits on the login endpoint. Using a pre-extracted token bypasses login entirely, avoiding 429 rate limit errors.
+
+----
+
+### Extracting App Token via MITM Proxy
+
+To get your `app_token` and `user_id` from the Zepp mobile app, you can use a MITM (Man-in-the-Middle) proxy to intercept the API traffic.
+
+#### Step 1: Install mitmproxy on your computer
+
+```sh
+# macOS
+brew install mitmproxy
+
+# Linux (Ubuntu/Debian)
+sudo apt install mitmproxy
+# or
+pip install mitmproxy
+
+# Windows
+# Download from https://mitmproxy.org/
+```
+
+#### Step 2: Start the proxy
+
+```sh
+mitmproxy --listen-port 8080
+```
+
+Note your computer's local IP address (e.g., `192.168.1.100`).
+
+#### Step 3: Configure your phone
+
+<details>
+<summary><strong>iPhone Instructions</strong></summary>
+
+**Set up proxy:**
+1. Connect iPhone to same WiFi as your computer
+2. Settings → WiFi → tap (i) next to your network
+3. Scroll down → Configure Proxy → Manual
+4. Server: `YOUR_COMPUTER_IP` (e.g., 192.168.1.100)
+5. Port: `8080`
+6. Save
+
+**Install certificate:**
+1. Open Safari on iPhone
+2. Go to: http://mitm.it
+3. Tap "Apple" → Download profile
+4. Settings → General → VPN & Device Management → mitmproxy → Install
+
+**Trust certificate:**
+1. Settings → General → About → Certificate Trust Settings
+2. Enable toggle for mitmproxy
+
+</details>
+
+<details>
+<summary><strong>Android Instructions</strong></summary>
+
+**Set up proxy:**
+1. Connect Android to same WiFi as your computer
+2. Settings → WiFi → Long press your network → Modify network
+3. Advanced options → Proxy → Manual
+4. Proxy hostname: `YOUR_COMPUTER_IP` (e.g., 192.168.1.100)
+5. Proxy port: `8080`
+6. Save
+
+**Install certificate:**
+1. Open Chrome on Android
+2. Go to: http://mitm.it
+3. Tap "Android" → Download certificate
+4. Settings → Security → Encryption & credentials → Install a certificate → CA certificate
+5. Select the downloaded `mitmproxy-ca-cert.cer` file
+
+> **Note:** On Android 7+, user-installed certificates are not trusted by apps by default. You may need a rooted device or use Android 6 or below for this to work with the Zepp app.
+
+</details>
+
+#### Step 4: Capture the token
+
+1. Open Zepp app on your phone
+2. Navigate around (sync data, view sleep, etc.)
+3. Watch mitmproxy terminal for requests to `api-mifit.huami.com` or `api-mifit.zepp.com`
+4. Press Enter on a request to see details
+5. Find in the headers:
+   - `apptoken` → use as `ZEPP_APP_TOKEN`
+   - `userid` (in URL params) → use as `ZEPP_USER_ID`
+
+#### Step 5: Cleanup (important!)
+
+**iPhone:**
+- Settings → WiFi → Configure Proxy → Off
+- Settings → General → VPN & Device Management → mitmproxy → Remove Profile
+
+**Android:**
+- Settings → WiFi → Your network → Proxy → None
+- Settings → Security → Encryption & credentials → Trusted credentials → User → Remove mitmproxy
+
+#### Step 6: Use the extracted values
+
+```sh
+export ZEPP_APP_TOKEN="your_captured_apptoken"
+export ZEPP_USER_ID="your_captured_userid"
+```
+
+Or in Docker:
+```sh
+docker run --rm \
+-e ZEPP_APP_TOKEN="your_token" \
+-e ZEPP_USER_ID="your_userid" \
+-e INFLUXDB_URL=http://192.168.3.84:8086 \
+...
+```
 
 ----
 

--- a/app/mifit_to_influxdb.py
+++ b/app/mifit_to_influxdb.py
@@ -773,13 +773,24 @@ def main():
     # Get the Zepp credentials
     config['ZEPP_EMAIL'] = os.getenv("ZEPP_EMAIL", False)
     config['ZEPP_PASS'] = os.getenv("ZEPP_PASS", False)
-    
-    if not config['ZEPP_EMAIL'] or not config['ZEPP_PASS']:
-        print("Error: Credentials not provided")
+    config['ZEPP_APP_TOKEN'] = os.getenv("ZEPP_APP_TOKEN", "")
+    config['ZEPP_USER_ID'] = os.getenv("ZEPP_USER_ID", "")
+
+    # Check for pre-configured token (bypasses rate-limited login)
+    if config['ZEPP_APP_TOKEN'] and config['ZEPP_USER_ID']:
+        print("Using pre-configured app_token (bypassing login)")
+        auth_info = {
+            'token_info': {
+                'app_token': config['ZEPP_APP_TOKEN'],
+                'user_id': config['ZEPP_USER_ID']
+            }
+        }
+    elif config['ZEPP_EMAIL'] and config['ZEPP_PASS']:
+        # Get logged in
+        auth_info = mifit_auth_email(config['ZEPP_EMAIL'], config['ZEPP_PASS'])
+    else:
+        print("Error: Provide ZEPP_APP_TOKEN+ZEPP_USER_ID or ZEPP_EMAIL+ZEPP_PASS")
         sys.exit(1)
-    
-    # Get logged in
-    auth_info=mifit_auth_email(config['ZEPP_EMAIL'], config['ZEPP_PASS'])
     
     # Fetch band info
     result_set, serial = get_band_data(auth_info, config)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+# WARNING: Change default passwords before exposing to network!
+# Default credentials are for local development only.
+
+services:
+  influxdb:
+    image: influxdb:2.7
+    container_name: zepp-influxdb
+    ports:
+      - "8086:8086"
+    environment:
+      - DOCKER_INFLUXDB_INIT_MODE=setup
+      - DOCKER_INFLUXDB_INIT_USERNAME=admin
+      - DOCKER_INFLUXDB_INIT_PASSWORD=adminpassword
+      - DOCKER_INFLUXDB_INIT_ORG=zepp
+      - DOCKER_INFLUXDB_INIT_BUCKET=zepp
+      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=zepp-token
+    volumes:
+      - influxdb-data:/var/lib/influxdb2
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: zepp-grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
+    depends_on:
+      - influxdb
+
+  zepp-sync:
+    build: .
+    container_name: zepp-sync
+    env_file:
+      - .env
+    depends_on:
+      - influxdb
+    restart: "no"
+
+volumes:
+  influxdb-data:


### PR DESCRIPTION
- Support ZEPP_APP_TOKEN + ZEPP_USER_ID environment variables
- Bypasses the rate-limited login endpoint (avoids 429 errors)
- Token can be extracted from Zepp mobile app via MITM proxy
- Add comprehensive MITM proxy setup instructions for iPhone and Android
- Add docker-compose.yml for easy deployment with InfluxDB